### PR TITLE
Cleanup tests

### DIFF
--- a/spec/lib/kushojin/controller_methods/send_change_filter_spec.rb
+++ b/spec/lib/kushojin/controller_methods/send_change_filter_spec.rb
@@ -4,13 +4,13 @@ require "kushojin/controller_methods/send_change_filter"
 RSpec.describe Kushojin::ControllerMethods::SendChangeFilter do
   describe "#around" do
     let(:logger) { Fluent::Logger::TestLogger.new }
-    let(:controller) { double(:UsersController) }
     let(:callback) do
       sender = Kushojin::Sender::EachSender.new(logger)
       Kushojin::ControllerMethods::SendChangeFilter.new(sender: sender)
     end
 
     before do
+      controller = double(:UsersController)
       req = double("ActionDispatch::Request")
 
       allow(controller).to receive_messages(
@@ -19,14 +19,14 @@ RSpec.describe Kushojin::ControllerMethods::SendChangeFilter do
         request:         req,
       )
       allow(req).to receive(:request_id).and_return("12345678-9abc-def0-1234-56789abcdef0")
-    end
 
-    it do
       callback.around(controller) do
         user = User.create(name: "bill", age: 20)
         user.update(name: "bob")
       end
+    end
 
+    it "should record a create log" do
       expect(logger.queue[0].tag).to eq("users.action")
       expect(logger.queue[0]).to match(
         "event"      => "create",
@@ -38,7 +38,9 @@ RSpec.describe Kushojin::ControllerMethods::SendChangeFilter do
           "age"  => [nil, 20],
         },
       )
+    end
 
+    it "should record a update log" do
       expect(logger.queue[1].tag).to eq("users.action")
       expect(logger.queue[1]).to match(
         "event"      => "update",

--- a/spec/lib/kushojin/controller_methods/send_change_filter_spec.rb
+++ b/spec/lib/kushojin/controller_methods/send_change_filter_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Kushojin::ControllerMethods::SendChangeFilter do
       end
     end
 
+    after do
+      User.delete_all
+    end
+
     it "should record a create log" do
       expect(logger.queue[0].tag).to eq("users.action")
       expect(logger.queue[0]).to match(

--- a/spec/lib/kushojin/sender/each_sender_spec.rb
+++ b/spec/lib/kushojin/sender/each_sender_spec.rb
@@ -2,7 +2,7 @@ require "spec_helper"
 
 RSpec.describe Kushojin::Sender::EachSender do
   describe "#send" do
-    let(:logger) { spy("Fluent::Logger::TestLogger") }
+    let(:logger) { Fluent::Logger::TestLogger.new }
     let(:controller) { double(:UsersController) }
 
     let(:user) { User.create(name: "bill", age: 20) }
@@ -38,12 +38,8 @@ RSpec.describe Kushojin::Sender::EachSender do
 
     it do
       subject
-      expect(logger).to have_received(:post).twice
-    end
-
-    it do
-      subject
-      map1 = {
+      expect(logger.queue[0].tag).to eq("users.action")
+      expect(logger.queue[0]).to match(
         "event"      => "create",
         "request_id" => "12345678-9abc-def0-1234-56789abcdef0",
         "table_name" => "users",
@@ -52,10 +48,10 @@ RSpec.describe Kushojin::Sender::EachSender do
           "name" => [nil, "bill"],
           "age"  => [nil, 20],
         },
-      }
-      expect(logger).to have_received(:post).with("users.action", map1).ordered
+      )
 
-      map2 = {
+      expect(logger.queue[1].tag).to eq("users.action")
+      expect(logger.queue[1]).to match(
         "event"      => "update",
         "request_id" => "12345678-9abc-def0-1234-56789abcdef0",
         "table_name" => "users",
@@ -64,8 +60,7 @@ RSpec.describe Kushojin::Sender::EachSender do
           "name" => ["bill", "bob"], # rubocop:disable Style/WordArray
           "age"  => [20, 21],
         },
-      }
-      expect(logger).to have_received(:post).with("users.action", map2).ordered
+      )
     end
   end
 end


### PR DESCRIPTION
* Use TestLogger instead of spy object
* Avoid unnecessary "let"
* Delete all records at end of test to ensure independency
* Add names of "it"