### PR TITLE
Analysis test coverage with Code Climate

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -23,12 +23,26 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
 
+      - name: Setup Code Climate test-reporter
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: |
+          curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+          chmod +x ./cc-test-reporter
+          ./cc-test-reporter before-build
+
       - name: Build and test with Rake
         run: |
           sudo apt-get update
           sudo apt-get install -y libsqlite3-dev
           gem install bundler
           bundle install --jobs 4 --retry 3
-          bundle exec rspec
+          COVERAGE=true bundle exec rspec
         env:
           BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}
+
+      - name: Upload coverage
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        run: |
+          ./cc-test-reporter after-build

--- a/kushojin.gemspec
+++ b/kushojin.gemspec
@@ -32,4 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sqlite3", "~> 1.3", ">= 1.3.6"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rubocop"
+  spec.add_development_dependency "simplecov"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,13 @@
 require "bundler/setup"
 require "active_record"
-require "kushojin"
 require "pry-byebug"
+
+if ENV["COVERAGE"]
+  require 'simplecov'
+  SimpleCov.start
+end
+
+require "kushojin"
 
 ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
 # ActiveRecord::Base.logger = ::Logger.new(STDOUT)


### PR DESCRIPTION
- Use [colszowka/simplecov](https://github.com/colszowka/simplecov) gem
  - Analysis only when the ```COVERAGE``` environment value is specified.
    README.md:
    > However, you can still accomplish this very easily by introducing an ENV variable conditional into your SimpleCov setup
    > block, like this:
    > 
    > ```ruby
    > SimpleCov.start if ENV["COVERAGE"]
    > ```
    > 
    > Then, SimpleCov will only run if you execute your tests like this:
    > 
    > ```shell
    > COVERAGE=true rake test
    > ```
- Use [codeclimate/test-reporter](https://github.com/codeclimate/test-reporter/) command
  - [https://docs.codeclimate.com/docs/configuring-test-coverage](https://docs.codeclimate.com/docs/configuring-test-coverage)